### PR TITLE
Remove lizenzhinweisgenerator project

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,7 +42,6 @@ $groupsToCheck = [
 	MG_LDAP_CLOUD => [
 		// 'project-bastion', // Not working...
 		'project-deployment-prep',
-		'project-lizenzhinweisgenerator',
 		// 'project-tools', // Not working....
 		'project-wikidata-dev',
 		'project-wikidata-query',


### PR DESCRIPTION
This project was [removed][1] as part of the [Cloud VPS 2020 Purge][2].

[1]: https://sal.toolforge.org/log/jQl3OXYBgTbpqNOmjRzL
[2]: https://wikitech.wikimedia.org/wiki/News/Cloud_VPS_2020_Purge#Deleted_lizenzhinweisgenerator